### PR TITLE
Fixed player walking sound not stopping upon entering a cutscene

### DIFF
--- a/scripts/scr_player_cutscenes/scr_player_cutscenes.gml
+++ b/scripts/scr_player_cutscenes/scr_player_cutscenes.gml
@@ -16,6 +16,7 @@ function scr_p_endtut(){
 	}
         x -= 1;
 		sprite_index = spr_player_kneel;
+		if (audio_is_playing(snd_p_walk_1)) audio_stop_sound(snd_p_walk_1)
         if(animation_end()) image_speed = 0;
 		if (wait <= 0){
         obj_cutscene_cam.y -= 0.4; 


### PR DESCRIPTION
Fixed the player walking sound not stopping when entering a cutscene